### PR TITLE
remove-pagination

### DIFF
--- a/rcpch_nhs_organisations/hospitals/views/country.py
+++ b/rcpch_nhs_organisations/hospitals/views/country.py
@@ -3,16 +3,12 @@ from rest_framework import (
     serializers,  # serializers here required for drf-spectacular @extend_schema
 )
 from rest_framework.decorators import api_view
-from rest_framework.views import APIView, Response
-from rest_framework.exceptions import ParseError
 from django_filters.rest_framework import DjangoFilterBackend
 
 from drf_spectacular.utils import (
     extend_schema,
-    OpenApiParameter,
     OpenApiExample,
     OpenApiResponse,
-    PolymorphicProxySerializer,
 )
 from drf_spectacular.types import OpenApiTypes
 
@@ -80,3 +76,4 @@ class CountryViewSet(viewsets.ReadOnlyModelViewSet):
         "globalid",
     ]
     filter_backends = (DjangoFilterBackend,)
+    pagination_class = None

--- a/rcpch_nhs_organisations/hospitals/views/integrated_care_board.py
+++ b/rcpch_nhs_organisations/hospitals/views/integrated_care_board.py
@@ -3,16 +3,12 @@ from rest_framework import (
     serializers,  # serializers here required for drf-spectacular @extend_schema
 )
 from rest_framework.decorators import api_view
-from rest_framework.views import APIView, Response
-from rest_framework.exceptions import ParseError
 from django_filters.rest_framework import DjangoFilterBackend
 
 from drf_spectacular.utils import (
     extend_schema,
-    OpenApiParameter,
     OpenApiExample,
     OpenApiResponse,
-    PolymorphicProxySerializer,
 )
 from drf_spectacular.types import OpenApiTypes
 
@@ -132,3 +128,4 @@ class IntegratedCareBoardOrganisationViewSet(viewsets.ReadOnlyModelViewSet):
         "publication_date",
     ]
     filter_backends = (DjangoFilterBackend,)
+    pagination_class = None

--- a/rcpch_nhs_organisations/hospitals/views/local_health_board.py
+++ b/rcpch_nhs_organisations/hospitals/views/local_health_board.py
@@ -3,16 +3,12 @@ from rest_framework import (
     serializers,  # serializers here required for drf-spectacular @extend_schema
 )
 from rest_framework.decorators import api_view
-from rest_framework.views import APIView, Response
-from rest_framework.exceptions import ParseError
 from django_filters.rest_framework import DjangoFilterBackend
 
 from drf_spectacular.utils import (
     extend_schema,
-    OpenApiParameter,
     OpenApiExample,
     OpenApiResponse,
-    PolymorphicProxySerializer,
 )
 from drf_spectacular.types import OpenApiTypes
 

--- a/rcpch_nhs_organisations/hospitals/views/london_borough.py
+++ b/rcpch_nhs_organisations/hospitals/views/london_borough.py
@@ -3,16 +3,12 @@ from rest_framework import (
     serializers,  # serializers here required for drf-spectacular @extend_schema
 )
 from rest_framework.decorators import api_view
-from rest_framework.views import APIView, Response
-from rest_framework.exceptions import ParseError
 from django_filters.rest_framework import DjangoFilterBackend
 
 from drf_spectacular.utils import (
     extend_schema,
-    OpenApiParameter,
     OpenApiExample,
     OpenApiResponse,
-    PolymorphicProxySerializer,
 )
 from drf_spectacular.types import OpenApiTypes
 
@@ -81,6 +77,7 @@ class LondonBoroughViewSet(viewsets.ReadOnlyModelViewSet):
         "sub_2006",
     ]
     filter_backends = (DjangoFilterBackend,)
+    pagination_class = None
 
 
 @extend_schema(

--- a/rcpch_nhs_organisations/hospitals/views/nhs_england_region.py
+++ b/rcpch_nhs_organisations/hospitals/views/nhs_england_region.py
@@ -3,16 +3,12 @@ from rest_framework import (
     serializers,  # serializers here required for drf-spectacular @extend_schema
 )
 from rest_framework.decorators import api_view
-from rest_framework.views import APIView, Response
-from rest_framework.exceptions import ParseError
 from django_filters.rest_framework import DjangoFilterBackend
 
 from drf_spectacular.utils import (
     extend_schema,
-    OpenApiParameter,
     OpenApiExample,
     OpenApiResponse,
-    PolymorphicProxySerializer,
 )
 from drf_spectacular.types import OpenApiTypes
 
@@ -206,3 +202,4 @@ class NHSEnglandRegionOrganisationViewSet(viewsets.ReadOnlyModelViewSet):
         "name",
     ]
     filter_backends = (DjangoFilterBackend,)
+    pagination_class = None

--- a/rcpch_nhs_organisations/hospitals/views/organisation.py
+++ b/rcpch_nhs_organisations/hospitals/views/organisation.py
@@ -3,17 +3,13 @@ from rest_framework import (
     serializers,  # serializers here required for drf-spectacular @extend_schema
 )
 from rest_framework.decorators import api_view
-from rest_framework.views import APIView, Response
-from rest_framework.exceptions import ParseError
 from django_filters.rest_framework import DjangoFilterBackend
 
 from drf_spectacular.utils import (
     extend_schema,
-    extend_schema_view,
     OpenApiParameter,
     OpenApiExample,
     OpenApiResponse,
-    PolymorphicProxySerializer,
 )
 from drf_spectacular.types import OpenApiTypes
 
@@ -140,3 +136,4 @@ class OrganisationViewSet(viewsets.ReadOnlyModelViewSet):
         "published_at",
     ]
     filter_backends = (DjangoFilterBackend,)
+    pagination_class = None

--- a/rcpch_nhs_organisations/hospitals/views/paediatric_diabetes_unit.py
+++ b/rcpch_nhs_organisations/hospitals/views/paediatric_diabetes_unit.py
@@ -2,17 +2,12 @@ from rest_framework import (
     viewsets,
     serializers,  # serializers here required for drf-spectacular @extend_schema
 )
-from rest_framework.decorators import api_view
-from rest_framework.views import APIView, Response
-from rest_framework.exceptions import ParseError
 from django_filters.rest_framework import DjangoFilterBackend
 
 from drf_spectacular.utils import (
     extend_schema,
-    OpenApiParameter,
     OpenApiExample,
     OpenApiResponse,
-    PolymorphicProxySerializer,
 )
 from drf_spectacular.types import OpenApiTypes
 
@@ -62,6 +57,7 @@ class PaediatricDiabetesUnitViewSet(viewsets.ReadOnlyModelViewSet):
         "pz_code",
     ]
     filter_backends = (DjangoFilterBackend,)
+    pagination_class = None
 
 
 @extend_schema(
@@ -106,3 +102,4 @@ class PaediatricDiabetesUnitWithNestedOrganisationsViewSet(
         "pz_code",
     ]
     filter_backends = (DjangoFilterBackend,)
+    pagination_class = None

--- a/rcpch_nhs_organisations/hospitals/views/trust.py
+++ b/rcpch_nhs_organisations/hospitals/views/trust.py
@@ -3,8 +3,6 @@ from rest_framework import (
     serializers,  # serializers here required for drf-spectacular @extend_schema
 )
 from rest_framework.decorators import api_view
-from rest_framework.views import APIView, Response
-from rest_framework.exceptions import ParseError
 from django_filters.rest_framework import DjangoFilterBackend
 
 from drf_spectacular.utils import (
@@ -12,7 +10,6 @@ from drf_spectacular.utils import (
     OpenApiParameter,
     OpenApiExample,
     OpenApiResponse,
-    PolymorphicProxySerializer,
 )
 from drf_spectacular.types import OpenApiTypes
 
@@ -94,3 +91,4 @@ class TrustViewSet(viewsets.ReadOnlyModelViewSet):
         "ods_code",
     ]
     filter_backends = (DjangoFilterBackend,)
+    pagination_class = None


### PR DESCRIPTION
Fixes rcpch/rcpch-nhs-organisations#4

### Overview
Removes paginations from all views. 

### Code changes
Remove pagination class from all views
Note this will remove pagination from the browsable API also. If in future the drf-spectacular schema works better with pagination we can put it back, but his would involve creating 2 views for each route - one for swagger and one without

### Documentation changes (done or required as a result of this PR)
No implications

### Related Issues
closes #4

### Mentions
@mbarton
