### PR TITLE
Pdu-from-organisation

### DIFF
--- a/rcpch_nhs_organisations/hospitals/serializers/__init__.py
+++ b/rcpch_nhs_organisations/hospitals/serializers/__init__.py
@@ -22,6 +22,7 @@ from .organisation import (
     LondonBoroughWithNestedOrganisationsSerializer,
     NHSEnglandRegionWithNestedOrganisationsSerializer,
     PaediatricDiabetesUnitWithNestedOrganisationSerializer,
+    PaediatricDiabetesUnitWithNestedOrganisationAndParentSerializer,
 )
 from .paediatric_diabetes_unit import PaediatricDiabetesUnitSerializer
 from .trust import TrustSerializer

--- a/rcpch_nhs_organisations/hospitals/urls.py
+++ b/rcpch_nhs_organisations/hospitals/urls.py
@@ -13,6 +13,7 @@ from .views import (
     NHSEnglandRegionOrganisationViewSet,
     PaediatricDiabetesUnitViewSet,
     PaediatricDiabetesUnitWithNestedOrganisationsViewSet,
+    PaediatricDiabetesUnitForOrganisationWithParentViewSet,
     TrustViewSet,
 )
 
@@ -27,9 +28,8 @@ router.register(
     basename="organisation-limited",
 )
 
-# returns a list of organisations and their nested parent details (without boundary data)
+# returns a list of organisations and their nested parent details (without boundary data) - this runs to 18,000 records so is possibly going to need pagination
 router.register(r"organisations", viewset=OrganisationViewSet, basename="organisation")
-
 
 # returns a list of trusts and their details with their nested child organisations (ods_code and name only)
 router.register(
@@ -92,22 +92,23 @@ router.register(
     viewset=PaediatricDiabetesUnitViewSet,
     basename="paediatric_diabetes_unit",
 )
+# returns a list of Paediatric Diabetes Units with nested child organisations
 router.register(
     r"paediatric_diabetes_units/organisations",
     viewset=PaediatricDiabetesUnitWithNestedOrganisationsViewSet,
     basename="paediatric_diabetes_unit",
 )
-# router.register(
-#     r"paediatric_diabetes_units/trusts",
-#     viewset=TrustWithNestedPaediatricDiabetesUnitsViewSet,
-#     basename="paediatric_diabetes_unit",
-# )
 
 
 drf_routes = [
     # rest framework paths
     path("", include(router.urls)),
     # JSON Schema
+    path(
+        "paediatric_diabetes_units/sibling-organisations/<str:ods_code>/",
+        PaediatricDiabetesUnitForOrganisationWithParentViewSet.as_view({"get": "list"}),
+        name="paediatric_diabetes_unit_organisation_with_parent",
+    ),
     path("schema/", SpectacularJSONAPIView.as_view(), name="schema"),
     # Swagger UI
     path("swagger-ui/", SpectacularSwaggerView.as_view(), name="swagger-ui"),


### PR DESCRIPTION
### Overview
Adds a new endpoint for NPDA to consume:
/paediatric_diabetes_units/sibling-organisations/<str:ods_code>/
This accepts an organisation ods_code and returns all the sibling organisations, the parent and the PZ code

### Code changes
2 new serializers, a new viewset, and a new URL