### PR TITLE
remove last migration and move to seed as azure too lacklustre to build in one go

### DIFF
--- a/rcpch_nhs_organisations/hospitals/management/commands/seed.py
+++ b/rcpch_nhs_organisations/hospitals/management/commands/seed.py
@@ -9,6 +9,7 @@ from .seed_functions import (
     seed_trusts,
     seed_pdus,
     ods_codes_to_abstraction_levels,
+    load_jersey_boundaries,
 )
 
 from .image import rcpch_ascii_art
@@ -46,6 +47,10 @@ class Command(BaseCommand):
             self.stdout.write(B + "Adding paediatric diabetes units..." + W)
             seed_pdus()
             rcpch_ascii_art()
+        elif options["model"] == "jersey":
+            self.stdout.write(B + "Adding Jersey boundaries..." + W)
+            load_jersey_boundaries()
+            rcpch_ascii_art()
         elif options["model"] == "all":
             self.stdout.write(
                 B + "Adding all organisations and levels of abstraction..." + W
@@ -54,6 +59,7 @@ class Command(BaseCommand):
             seed_trusts()
             seed_organisations()
             seed_pdus()
+            load_jersey_boundaries()
             rcpch_ascii_art()
 
         else:

--- a/rcpch_nhs_organisations/hospitals/management/commands/seed_functions/__init__.py
+++ b/rcpch_nhs_organisations/hospitals/management/commands/seed_functions/__init__.py
@@ -1,4 +1,5 @@
 from .abstraction_levels import *
+from .jersey import *
 from .organisations import *
 from .pdus import *
 from .trusts import *

--- a/rcpch_nhs_organisations/hospitals/management/commands/seed_functions/jersey.py
+++ b/rcpch_nhs_organisations/hospitals/management/commands/seed_functions/jersey.py
@@ -1,4 +1,3 @@
-from django.db import migrations
 from django.apps import apps as django_apps
 
 import os
@@ -10,8 +9,8 @@ app_path = app_config.path
 Jersey_Boundary_File = os.path.join(app_path, "shape_files", "Jersey", "CLC06_UK.shp")
 
 
-def load_jersey_boundaries(apps, schema_editor, verbose=True):
-    JerseyBoundaries = apps.get_model("hospitals", "JerseyBoundaries")
+def load_jersey_boundaries():
+    JerseyBoundaries = django_apps.get_model("hospitals", "JerseyBoundaries")
     jerseyboundaries_mapping = {
         "objectid": "OBJECTID",
         "shape_id": "ID",
@@ -30,12 +29,3 @@ def load_jersey_boundaries(apps, schema_editor, verbose=True):
         encoding="iso-8859-1",
     )
     lm.save(strict=True, verbose=True)
-
-
-class Migration(migrations.Migration):
-
-    dependencies = [
-        ("hospitals", "0004_jerseyboundaries"),
-    ]
-
-    operations = [migrations.RunPython(load_jersey_boundaries)]


### PR DESCRIPTION
Frustrating state of affairs that Azure times out mid-build while database seeding triggering a restart so that the Jersey boundary table just grows and grows

This PR therefore removes the seeding from the migration and puts it in a manage.py seed function to be called from the command line
