### PR TITLE
Rcpch-pdu

### DIFF
--- a/rcpch_nhs_organisations/hospitals/admin.py
+++ b/rcpch_nhs_organisations/hospitals/admin.py
@@ -1,3 +1,15 @@
 from django.contrib import admin
 
 # Register your models here.
+from .models import (
+    LocalHealthBoard,
+    Organisation,
+    PaediatricDiabetesUnit,
+    Trust,
+)
+
+# Register your models here.
+admin.site.register(LocalHealthBoard)
+admin.site.register(Organisation)
+admin.site.register(PaediatricDiabetesUnit)
+admin.site.register(Trust)

--- a/rcpch_nhs_organisations/hospitals/constants/paediatric_diabetes_units.py
+++ b/rcpch_nhs_organisations/hospitals/constants/paediatric_diabetes_units.py
@@ -170,8 +170,8 @@ PZ_CODES = [
     {"ods_code": "RWFTW", "npda_code": "PZ216"},
     {"ods_code": "RDU01", "npda_code": "PZ218"},
     {"ods_code": "RCUEF", "npda_code": "PZ219"},
-    {"ods_code": "RC979", "npda_code": "PZ220"},  # RC112 Bedford Hospital
-    {"ods_code": "RGT2X", "npda_code": "PZ220"},  # RC112 Luton and Dunstable Hospital
+    {"ods_code": "RC979", "npda_code": "PZ220"},  # Bedford Hospital
+    {"ods_code": "RGT2X", "npda_code": "PZ010"},  # Luton and Dunstable Hospital
     {"ods_code": "RN325", "npda_code": "PZ221"},
     {"ods_code": "RL403", "npda_code": "PZ222"},
     {"ods_code": "RXK01", "npda_code": "PZ223"},

--- a/rcpch_nhs_organisations/hospitals/constants/paediatric_diabetes_units.py
+++ b/rcpch_nhs_organisations/hospitals/constants/paediatric_diabetes_units.py
@@ -187,4 +187,5 @@ PZ_CODES = [
         "ods_code": "RGT1W",
         "npda_code": "PZ248",
     },  # Jersey General Hospital added 22/6/24
+    {"ods_code": "8HV48", "npda_code": "PZ999"},
 ]

--- a/rcpch_nhs_organisations/hospitals/constants/paediatric_diabetes_units.py
+++ b/rcpch_nhs_organisations/hospitals/constants/paediatric_diabetes_units.py
@@ -187,5 +187,5 @@ PZ_CODES = [
         "ods_code": "RGT1W",
         "npda_code": "PZ248",
     },  # Jersey General Hospital added 22/6/24
-    {"ods_code": "8HV48", "npda_code": "PZ999"},
+    {"ods_code": "8HV48", "npda_code": "PZ999"},  # RCPCH
 ]

--- a/rcpch_nhs_organisations/hospitals/serializers/__init__.py
+++ b/rcpch_nhs_organisations/hospitals/serializers/__init__.py
@@ -25,4 +25,4 @@ from .organisation import (
     PaediatricDiabetesUnitWithNestedOrganisationAndParentSerializer,
 )
 from .paediatric_diabetes_unit import PaediatricDiabetesUnitSerializer
-from .trust import TrustSerializer
+from .trust import TrustSerializer, PaediatricDiabetesUnitWithNestedTrustSerializer

--- a/rcpch_nhs_organisations/hospitals/serializers/trust.py
+++ b/rcpch_nhs_organisations/hospitals/serializers/trust.py
@@ -1,8 +1,13 @@
 from rest_framework import serializers
+from django.apps import apps
 
 from drf_spectacular.utils import extend_schema_serializer, OpenApiExample
 
-from ..models import Trust
+from .local_health_board import LocalHealthBoardLimitedSerializer
+
+Organisation = apps.get_model("hospitals", "Organisation")
+PaediatricDiabetesUnit = apps.get_model("hospitals", "PaediatricDiabetesUnit")
+Trust = apps.get_model("hospitals", "Trust")
 
 
 @extend_schema_serializer(
@@ -43,3 +48,88 @@ class TrustSerializer(serializers.ModelSerializer):
             "active",
             "published_at",
         ]
+
+
+@extend_schema_serializer(
+    examples=[
+        OpenApiExample(
+            "paediatric_diabetes_units/trust/",
+            value={"pz_code": "", "trust": []},
+            response_only=True,
+        )
+    ]
+)
+class PaediatricDiabetesUnitWithNestedTrustSerializer(serializers.ModelSerializer):
+    parent = serializers.SerializerMethodField()
+    primary_organisation = serializers.SerializerMethodField()
+
+    class Meta:
+        model = PaediatricDiabetesUnit
+        fields = ["pz_code", "parent", "primary_organisation"]
+
+    def get_parent(self, obj):
+        try:
+            # all related organisations for that PaediatricDiabetesUnit should have the same parent
+            # so we can just get the first one
+            organisation = Organisation.objects.filter(
+                paediatric_diabetes_unit=obj
+            ).first()
+        except Organisation.DoesNotExist:
+            return None
+
+        if organisation.trust:
+            return TrustSerializer(organisation.trust).data
+        elif organisation.local_health_board:
+            return LocalHealthBoardLimitedSerializer(
+                organisation.local_health_board
+            ).data
+        return None
+
+    def get_primary_organisation(self, obj):
+        # prevents circular import
+        from rcpch_nhs_organisations.hospitals.serializers.organisation import (
+            OrganisationNoParentsSerializer,
+        )
+
+        try:
+            organisations = Organisation.objects.filter(
+                paediatric_diabetes_unit=obj
+            ).all()
+        except Organisation.DoesNotExist:
+            return None
+
+        if organisations.count() > 1:
+            if obj.pz_code == "PZ024":
+                # RPF01 is the parent organisation for PZ024 (William Harvey Hospital, Ashford)
+                return OrganisationNoParentsSerializer(
+                    organisations.filter(ods_code="RVV01").get()
+                ).data
+            elif obj.pz_code == "PZ050":
+                # RPF01 is the parent organisation for PZ024 (Queen Mary's Hospital for Children, Carshalton)
+                return OrganisationNoParentsSerializer(
+                    organisations.filter(ods_code="RVR07").get()
+                ).data
+            elif obj.pz_code == "PZ099":
+                # RPF01 is the parent organisation for PZ099 (Lister Hospital, Stevenage)
+                return OrganisationNoParentsSerializer(
+                    organisations.filter(ods_code="RWH01").get()
+                ).data
+            elif obj.pz_code == "PZ136":
+                # RPF01 is the parent organisation for PZ099 (Manchester Children's Hospital)
+                return OrganisationNoParentsSerializer(
+                    organisations.filter(ods_code="R0A03").get()
+                ).data
+            elif obj.pz_code == "PZ206":
+                # RM401 is the parent organisation for PZ206 (Trafford General Hospital)
+                return OrganisationNoParentsSerializer(
+                    organisations.filter(ods_code="RM321").get()
+                ).data
+            elif obj.pz_code == "PZ230":
+                # RM230 is the parent organisation for PZ230 (Conquest Hospital, Hastings)
+                return OrganisationNoParentsSerializer(
+                    organisations.filter(ods_code="RXC01").get()
+                ).data
+            else:
+                return OrganisationNoParentsSerializer(organisations.first()).data
+        else:
+            return OrganisationNoParentsSerializer(organisations.get()).data

--- a/rcpch_nhs_organisations/hospitals/urls.py
+++ b/rcpch_nhs_organisations/hospitals/urls.py
@@ -15,12 +15,15 @@ from .views import (
     PaediatricDiabetesUnitViewSet,
     PaediatricDiabetesUnitWithNestedOrganisationsViewSet,
     PaediatricDiabetesUnitForOrganisationWithParentViewSet,
+    PaediatricDiabetesUnitForTrustViewSet,
     TrustViewSet,
 )
 
 from drf_spectacular.views import SpectacularJSONAPIView, SpectacularSwaggerView
 
 router = routers.DefaultRouter()
+
+from django.contrib import admin
 
 # returns a limited list of organisations by name and ods code
 router.register(
@@ -99,6 +102,12 @@ router.register(
     viewset=PaediatricDiabetesUnitWithNestedOrganisationsViewSet,
     basename="paediatric_diabetes_unit",
 )
+# returns a list of Paediatric Diabetes Units with nested trusts
+router.register(
+    r"paediatric_diabetes_units/trust",
+    viewset=PaediatricDiabetesUnitForTrustViewSet,
+    basename="paediatric_diabetes_unit",
+)
 
 drf_routes = [
     # rest framework paths
@@ -120,6 +129,8 @@ drf_routes = [
 ]
 
 urlpatterns = []
+
+urlpatterns += (path("admin/", admin.site.urls),)
 
 
 urlpatterns += drf_routes

--- a/rcpch_nhs_organisations/hospitals/views/paediatric_diabetes_unit.py
+++ b/rcpch_nhs_organisations/hospitals/views/paediatric_diabetes_unit.py
@@ -179,9 +179,9 @@ class PaediatricDiabetesUnitForOrganisationWithParentViewSet(viewsets.ViewSet):
             location=OpenApiParameter.QUERY,
         ),
     ],
-    summary="This endpoint returns a list of NHS Trusts within a Paediatric Diabetes Unit (with their parent), against an ODS code.",
+    summary="This endpoint returns the parent NHS Trust for a given Paediatric Diabetes Unit (with their primary organisation), against a PZ code. If no code is provide, a list is returned.",
 )
-class PaediatricDiabetesUnitForTrustViewSet(viewsets.ModelViewSet):
+class PaediatricDiabetesUnitForTrustViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = PaediatricDiabetesUnit.objects.all()
     serializer_class = PaediatricDiabetesUnitWithNestedTrustSerializer
 

--- a/rcpch_nhs_organisations/hospitals/views/paediatric_diabetes_unit.py
+++ b/rcpch_nhs_organisations/hospitals/views/paediatric_diabetes_unit.py
@@ -20,6 +20,7 @@ from ..serializers import (
     PaediatricDiabetesUnitSerializer,
     PaediatricDiabetesUnitWithNestedOrganisationSerializer,
     PaediatricDiabetesUnitWithNestedOrganisationAndParentSerializer,
+    PaediatricDiabetesUnitWithNestedTrustSerializer,
 )
 
 
@@ -149,3 +150,44 @@ class PaediatricDiabetesUnitForOrganisationWithParentViewSet(viewsets.ViewSet):
             queryset, many=True
         )
         return Response(serializer.data)
+
+
+@extend_schema(
+    request=PaediatricDiabetesUnitWithNestedTrustSerializer,
+    responses={
+        200: OpenApiResponse(
+            response=OpenApiTypes.OBJECT,
+            description="Valid Response",
+            examples=[
+                OpenApiExample(
+                    "paediatric_diabetes_units/trust/RGT/",
+                    external_value="external value",
+                    value={
+                        "pz_code": "PZ215",
+                    },
+                    response_only="true",
+                ),
+            ],
+        ),
+    },
+    parameters=[
+        OpenApiParameter(
+            name="pz_code",
+            description="PZ Code of the Paediatric Diabetes Unit",
+            required=False,
+            type=OpenApiTypes.STR,
+            location=OpenApiParameter.QUERY,
+        ),
+    ],
+    summary="This endpoint returns a list of NHS Trusts within a Paediatric Diabetes Unit (with their parent), against an ODS code.",
+)
+class PaediatricDiabetesUnitForTrustViewSet(viewsets.ModelViewSet):
+    queryset = PaediatricDiabetesUnit.objects.all()
+    serializer_class = PaediatricDiabetesUnitWithNestedTrustSerializer
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        pz_code = self.request.query_params.get("pz_code", None)
+        if pz_code is not None:
+            queryset = queryset.filter(pz_code=pz_code)
+        return queryset


### PR DESCRIPTION
### Overview
Creates a new endpoint returning `paediatric_diabetes_units/paediatric_diabetes_units_trust_list` with the structure:
```json
{
    "pz_code": "PZ215",
    "parent": {
      "ods_code": "RJZ",
      "name": "KING'S COLLEGE HOSPITAL NHS FOUNDATION TRUST",
      "address_line_1": "DENMARK HILL",
      "address_line_2": "",
      "town": "LONDON",
      "postcode": "SE5 9RS",
      "country": "ENGLAND",
      "telephone": null,
      "website": null,
      "active": true,
      "published_at": null
    },
    "primary_organisation": {
      "ods_code": "RJZ01",
      "name": "KING'S COLLEGE HOSPITAL (DENMARK HILL)"
    }
  }
```
If no pz code is supplied, a list is supplied.

This returns the PZ code, the associated trust and the lead PDU organisation if more than one organisation.
RCPCH has been added as PZ code PZ999

### Code changes
Adds a new serializer and a viewset, and a new endpoint to `urls.py`
Only GET requests are accepted
All the models are now also registered with admin.

### Documentation changes (done or required as a result of this PR)
This is in swagger

### Related Issues
This is part of NPDA implementation
As part of this Bedford and Luton (which are the same trust) have been updated to reflect they have different PZ numbers - closes #23