### PR TITLE
gis serializers

### DIFF
--- a/rcpch_nhs_organisations/hospitals/serializers/integrated_care_board.py
+++ b/rcpch_nhs_organisations/hospitals/serializers/integrated_care_board.py
@@ -1,5 +1,6 @@
 from django.apps import apps
 from rest_framework import serializers
+from rest_framework_gis.serializers import GeoFeatureModelSerializer
 
 from drf_spectacular.utils import extend_schema_serializer, OpenApiExample
 
@@ -26,10 +27,10 @@ from ..models import IntegratedCareBoard
         )
     ]
 )
-class IntegratedCareBoardSerializer(serializers.ModelSerializer):
+class IntegratedCareBoardSerializer(GeoFeatureModelSerializer):
     class Meta:
         model = IntegratedCareBoard
-        # depth = 1
+        geo_field = "geom"
         fields = [
             "boundary_identifier",
             "name",

--- a/rcpch_nhs_organisations/hospitals/serializers/local_authority_district.py
+++ b/rcpch_nhs_organisations/hospitals/serializers/local_authority_district.py
@@ -1,4 +1,5 @@
 from django.apps import apps
+from rest_framework_gis.serializers import GeoFeatureModelSerializer
 from rest_framework import serializers
 
 from drf_spectacular.utils import extend_schema_serializer, OpenApiExample
@@ -25,10 +26,10 @@ from ..models import LocalAuthorityDistrict
         )
     ]
 )
-class LocalAuthorityDistrictSerializer(serializers.ModelSerializer):
+class LocalAuthorityDistrictSerializer(GeoFeatureModelSerializer):
     class Meta:
         model = LocalAuthorityDistrict
-        # depth = 1
+        geo_field = "geom"
         fields = [
             "lad24cd",
             "lad24nm",

--- a/rcpch_nhs_organisations/hospitals/serializers/local_health_board.py
+++ b/rcpch_nhs_organisations/hospitals/serializers/local_health_board.py
@@ -1,6 +1,6 @@
 from django.apps import apps
 from rest_framework import serializers
-
+from rest_framework_gis.serializers import GeoFeatureModelSerializer
 from drf_spectacular.utils import extend_schema_serializer, OpenApiExample
 
 
@@ -28,10 +28,11 @@ from ..models import LocalHealthBoard
         )
     ]
 )
-class LocalHealthBoardSerializer(serializers.ModelSerializer):
+class LocalHealthBoardSerializer(GeoFeatureModelSerializer):
     # returns local health boards and boundary data
     class Meta:
         model = LocalHealthBoard
+        geo_field = "geom"
         fields = [
             "ods_code",
             "publication_date",

--- a/rcpch_nhs_organisations/hospitals/serializers/london_borough.py
+++ b/rcpch_nhs_organisations/hospitals/serializers/london_borough.py
@@ -1,6 +1,6 @@
 from django.apps import apps
 from rest_framework import serializers
-
+from rest_framework_gis.serializers import GeoFeatureModelSerializer
 from drf_spectacular.utils import extend_schema_serializer, OpenApiExample
 
 from ..models import LondonBorough
@@ -27,7 +27,7 @@ from ..models import LondonBorough
 class LondonBoroughSerializer(serializers.ModelSerializer):
     class Meta:
         model = LondonBorough
-        # depth = 1
+        geo_field = "geom"
         fields = [
             "name",
             "gss_code",

--- a/rcpch_nhs_organisations/hospitals/serializers/nhs_england_region.py
+++ b/rcpch_nhs_organisations/hospitals/serializers/nhs_england_region.py
@@ -1,6 +1,6 @@
 from django.apps import apps
 from rest_framework import serializers
-
+from rest_framework_gis.serializers import GeoFeatureModelSerializer
 from drf_spectacular.utils import extend_schema_serializer, OpenApiExample
 
 from ..models import NHSEnglandRegion
@@ -28,11 +28,11 @@ from ..models import NHSEnglandRegion
         )
     ]
 )
-class NHSEnglandRegionSerializer(serializers.ModelSerializer):
+class NHSEnglandRegionSerializer(GeoFeatureModelSerializer):
     # returns NHS England regions and boundaries
     class Meta:
         model = NHSEnglandRegion
-        # depth = 1
+        geo_field = "geom"
         fields = [
             "region_code",
             "publication_date",

--- a/rcpch_nhs_organisations/hospitals/serializers/organisation.py
+++ b/rcpch_nhs_organisations/hospitals/serializers/organisation.py
@@ -4546,7 +4546,7 @@ from .trust import TrustSerializer
         )
     ]
 )
-class OrganisationSerializer(serializers.ModelSerializer):
+class OrganisationSerializer(GeoFeatureModelSerializer):
     # Serializes an organisation, nest in all related parent details (without boundaries)
     trust = TrustSerializer()
     local_health_board = LocalHealthBoardLimitedSerializer()
@@ -4563,6 +4563,7 @@ class OrganisationSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Organisation
+        geo_field = "geocode_coordinates"
         fields = [
             "ods_code",
             "name",

--- a/rcpch_nhs_organisations/hospitals/serializers/organisation.py
+++ b/rcpch_nhs_organisations/hospitals/serializers/organisation.py
@@ -1,4 +1,5 @@
 from django.apps import apps
+from rest_framework_gis.serializers import GeoFeatureModelSerializer
 from rest_framework import serializers
 
 from drf_spectacular.utils import (
@@ -8,20 +9,17 @@ from drf_spectacular.utils import (
 )
 
 from ..models import (
-    Country,
     Organisation,
     IntegratedCareBoard,
     LocalHealthBoard,
     LondonBorough,
     NHSEnglandRegion,
     Trust,
-    OPENUKNetwork,
     PaediatricDiabetesUnit,
 )
 
-from .country import CountrySerializer, CountryLimitedSerializer
+from .country import CountryLimitedSerializer
 from .integrated_care_board import (
-    IntegratedCareBoardSerializer,
     IntegratedCareBoardLimitedSerializer,
 )
 from .local_authority_district import LocalAuthorityDistrictSerializer
@@ -29,10 +27,9 @@ from .local_health_board import (
     LocalHealthBoardSerializer,
     LocalHealthBoardLimitedSerializer,
 )
-from .london_borough import LondonBoroughSerializer, LondonBoroughLimitedSerializer
+from .london_borough import LondonBoroughLimitedSerializer
 from .lower_layer_super_output_area import LowerLayerSuperOutputAreaSerializer
 from .nhs_england_region import (
-    NHSEnglandRegionSerializer,
     NHSEnglandRegionLimitedSerializer,
 )
 from .openuk_network import OPENUKNetworkSerializer
@@ -4805,10 +4802,11 @@ class PaediatricDiabetesUnitWithNestedOrganisationSerializer(
         )
     ]
 )
-class OrganisationWithParentSerializer(serializers.ModelSerializer):
+class OrganisationWithParentSerializer(GeoFeatureModelSerializer):
     parent = serializers.SerializerMethodField()
 
     class Meta:
+        geo_field = "geom"
         model = Organisation
         fields = ["ods_code", "name", "parent"]
 
@@ -4831,12 +4829,13 @@ class OrganisationWithParentSerializer(serializers.ModelSerializer):
     ]
 )
 class PaediatricDiabetesUnitWithNestedOrganisationAndParentSerializer(
-    serializers.ModelSerializer
+    GeoFeatureModelSerializer
 ):
     organisations = OrganisationWithParentSerializer(
         many=True, read_only=True, source="paediatric_diabetes_unit_organisations"
     )
 
     class Meta:
+        geo_field = "geom"
         model = PaediatricDiabetesUnit
         fields = ["pz_code", "organisations"]

--- a/rcpch_nhs_organisations/hospitals/views/local_authority_district.py
+++ b/rcpch_nhs_organisations/hospitals/views/local_authority_district.py
@@ -104,8 +104,8 @@ class LocalAuthorityDistrictViewSet(viewsets.ReadOnlyModelViewSet):
             ),
         ],
         responses={200: LocalAuthorityDistrictSerializer(many=True)},
-        summary="Get a list of Local Authority Districts within a given radius of a point.",
-        description="This endpoint returns a list of Local Authority Districts within a given radius of a point.",
+        summary="Get Local Authority Districts within a radius",
+        description="This endpoint returns a list of Local Authority Districts within a specified radius from a given latitude and longitude.",
     )
     @action(detail=False, methods=["get"])
     def within_radius(self, request):

--- a/rcpch_nhs_organisations/settings.py
+++ b/rcpch_nhs_organisations/settings.py
@@ -76,6 +76,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "django.contrib.gis",
     "rest_framework",
+    "rest_framework_gis",
     "django_filters",
     "drf_spectacular",
     "rcpch_nhs_organisations.hospitals",


### PR DESCRIPTION
### Overview
Adds the GIS serializer classes to all the serializers.

This means the geometry returned from the API will nolonger be impossible to deserialize in the client

closes #52