### PR TITLE
deploy-docs-gh-pages

### DIFF
--- a/.github/workflows/main_rcpch-nhs-organisations.yml
+++ b/.github/workflows/main_rcpch-nhs-organisations.yml
@@ -5,13 +5,15 @@
 name: Build and deploy Python app to Azure Web App - rcpch-nhs-organisations. Deploy docs to GitHub Pages
 
 on:
-  push:
+  pull_request:
     branches:
       - live
-  workflow_dispatch:
+    types:
+      - closed
 
 jobs:
   build-and-deploy:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:
@@ -35,8 +37,34 @@ jobs:
           package: "."
 
   deploy-mkdocs:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     needs: build-and-deploy
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python version
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.11"
+
+      - name: Install MkDocs and dependencies
+        run: |
+          pip install mkdocs mkdocs-material
+
+      - name: Build MkDocs site
+        run: mkdocs build --config-file documentation/mkdocs.yml
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+
+  deploy-mkdocs-only:
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.title, '[docs]')
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main_rcpch-nhs-organisations.yml
+++ b/.github/workflows/main_rcpch-nhs-organisations.yml
@@ -2,7 +2,7 @@
 # More GitHub Actions for Azure: https://github.com/Azure/actions
 # More info on Python, GitHub Actions, and Azure App Service: https://aka.ms/python-webapps-actions
 
-name: Build and deploy Python app to Azure Web App - rcpch-nhs-organisations
+name: Build and deploy Python app to Azure Web App - rcpch-nhs-organisations. Deploy docs to GitHub Pages
 
 on:
   push:
@@ -33,3 +33,28 @@ jobs:
           app-name: "RCPCH-NHS-organisations"
           publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_A76B7421A08D44778EBB49AB30B51B3D }}
           package: "."
+
+  deploy-mkdocs:
+    runs-on: ubuntu-latest
+    needs: build-and-deploy
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python version
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.11"
+
+      - name: Install MkDocs and dependencies
+        run: |
+          pip install mkdocs mkdocs-material
+
+      - name: Build MkDocs site
+        run: mkdocs build --config-file documentation/mkdocs.yml
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site


### PR DESCRIPTION
### Overview
Adds a new github action that:
1. alters deploy to azure only on merge and close PR to live
2. deploy to azure is always followed by deploy of docs
3. if commit message contains '[docs]', only the docs are published

closes #49