### PR TITLE
Make Gloucestershire Royal Hospital the lead for PZ242

### DIFF
--- a/rcpch_nhs_organisations/hospitals/constants/paediatric_diabetes_units.py
+++ b/rcpch_nhs_organisations/hospitals/constants/paediatric_diabetes_units.py
@@ -207,6 +207,7 @@ PZ_CODES = [
     {"ods_code": "RHU03", "npda_code": "PZ238", "active": 1},
     {"ods_code": "RNA01", "npda_code": "PZ240", "active": 1},
     {"ods_code": "RTE01", "npda_code": "PZ242", "active": 1},
+    {"ods_code": "RTE03", "npda_code": "PZ242", "active": 1},
     {
         "ods_code": "RGT1W",
         "npda_code": "PZ248",
@@ -1234,7 +1235,7 @@ PZ_CODES_NETWORKS = [
         "network_code": "PN08",
     },
     {
-        "ods_code": "RTE01",
+        "ods_code": "RTE03",
         "npda_code": "PZ242",
         "network_name": "South West",
         "network_code": "PN02",

--- a/rcpch_nhs_organisations/hospitals/serializers/trust.py
+++ b/rcpch_nhs_organisations/hospitals/serializers/trust.py
@@ -204,6 +204,15 @@ class PaediatricDiabetesUnitWithNestedParentSerializer(serializers.ModelSerializ
                         ods_code="R0B01"
                     ).get()  # Sunderland Royal Hospital
                 ).data
+            elif obj.pz_code == "PZ242":
+                # PZ242 is GLOUCESTERSHIRE HOSPITALS NHS FOUNDATION TRUST
+                #  - RTE01	CHELTENHAM GENERAL HOSPITAL 
+                #  - RTE03	GLOUCESTERSHIRE ROYAL HOSPITAL (lead)
+                return OrganisationNoParentsSerializer(
+                    organisations.filter(
+                        ods_code="RTE03"
+                    ).get()  # GLOUCESTERSHIRE ROYAL HOSPITAL
+                ).data
             else:
                 return OrganisationNoParentsSerializer(organisations.first()).data
         else:


### PR DESCRIPTION
The NPDA audit team got in touch to say they couldn't find PZ242 in the platform. It was there but under Cheltenham General Hospital. They requested that Gloucestershire Royal Hospital be added and set to the lead org for that PDU.