### PR TITLE
South tees

### DIFF
--- a/rcpch_nhs_organisations/hospitals/constants/integrated_care_boards.py
+++ b/rcpch_nhs_organisations/hospitals/constants/integrated_care_boards.py
@@ -1,6 +1,6 @@
 """
 This constant is used for seeding the ICB table
-Contains INTEGRATED_CARE_BOARDS to seed the 42 ICBs 
+Contains INTEGRATED_CARE_BOARDS to seed the 42 ICBs
 Contains INTEGRATED_CARE_BOARDS_LOCAL_AUTHORITIES, matching Trusts to ICBs
 """
 
@@ -703,9 +703,9 @@ INTEGRATED_CARE_BOARDS_LOCAL_AUTHORITIES = [
     {
         "NHS England Region": "North East and Yorkshire",
         "NHS England Region Code": "Y63",
-        "ODS ICB Code": "QOQ",
+        "ODS ICB Code": "QHM",
         "ONS ICB Boundary Code": "E54000051",
-        "ICB Name": "NHS HUMBER AND NORTH YORKSHIRE INTEGRATED CARE BOARD",
+        "ICB Name": "NHS NORTH EAST AND NORTH CUMBRIA INTEGRATED CARE BOARD",
         "Sub ICB Locations (formerly CCGs)": "",
         "ODS Sub ICB Code": "",
         "Local Authority": "",

--- a/rcpch_nhs_organisations/hospitals/views/trust.py
+++ b/rcpch_nhs_organisations/hospitals/views/trust.py
@@ -6,6 +6,7 @@ from rest_framework import (
     serializers,  # serializers here required for drf-spectacular @extend_schema
 )
 from rest_framework.decorators import action
+from rest_framework.response import Response
 
 # Third-party imports
 from django_filters.rest_framework import DjangoFilterBackend
@@ -171,5 +172,8 @@ class TrustViewSet(viewsets.ReadOnlyModelViewSet):
     @action(
         detail=True, methods=["get"], url_path="organisations", url_name="organisations"
     )
-    def retrieve_trust_organisations(self, request):
-        return super().retrieve(request)
+    @action(detail=True, url_path="organisations", url_name="organisations")
+    def retrieve_trust_organisations(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = TrustWithNestedOrganisationsSerializer(instance)
+        return Response(serializer.data)


### PR DESCRIPTION
Overview
South Tees NHS Trust is part of NHS NORTH EAST AND NORTH CUMBRIA INTEGRATED CARE BOARD, NOT NHS HUMBER AND NORTH YORKSHIRE INTEGRATED CARE BOARD

This PR updates the seeding to reflect this for future instances.

It incidentally fixes the trust viewset which was erroring for the nested organisations endpoint.

to finish this the organisations related to South Tees Trust need to have their ICB relationships to be updated too.

South Tees NHS Trust (RTR) has organisations:

RTR45: FRIARAGE HOSPITAL SITE
RTRAT: THE JAMES COOK UNIVERSITY HOSPITAL
The need moving from
NHS HUMBER AND NORTH YORKSHIRE INTEGRATED CARE BOARD (QOQ)
to:
NHS NORTH EAST AND NORTH CUMBRIA INTEGRATED CARE BOARD (QHM)