### PR TITLE
Fix Luton and Dunstable hospital PDU organisation

### DIFF
--- a/rcpch_nhs_organisations/hospitals/constants/paediatric_diabetes_units.py
+++ b/rcpch_nhs_organisations/hospitals/constants/paediatric_diabetes_units.py
@@ -192,7 +192,7 @@ PZ_CODES = [
     {"ods_code": "RCUEF", "npda_code": "PZ219", "active": 1},
     {"ods_code": "RC979", "npda_code": "PZ220", "active": 1},  # Bedford Hospital
     {
-        "ods_code": "RGT2X",
+        "ods_code": "RC971",
         "npda_code": "PZ010",
         "active": 1,
     },  # Luton and Dunstable Hospital
@@ -1202,7 +1202,7 @@ PZ_CODES_NETWORKS = [
         "network_code": "PN06",
     },
     {
-        "ods_code": "RGT2X",
+        "ods_code": "RC971",
         "npda_code": "PZ010",
         "network_name": "East of England",
         "network_code": "PN06",


### PR DESCRIPTION
It seems like it was incorrectly changed in #97 so it's currently showing as `CAMBRIDGE UNIVERSITY HOSPITAL NHS FOUNDATION TRUST` in the NPDA platform.

This PR fixes the seed code. I will manually update it in the deployment.