### PR TITLE
Fix seed pdus

### DIFF
--- a/rcpch_nhs_organisations/hospitals/constants/paediatric_diabetes_units.py
+++ b/rcpch_nhs_organisations/hospitals/constants/paediatric_diabetes_units.py
@@ -182,7 +182,7 @@ PZ_CODES = [
     {
         "ods_code": "RM3",
         "npda_code": "PZ206",
-        "active": 1,
+        "active": 0,
     },  # Pennine Acute Hospitals NHS Trust was RW6 and merged with Salford Royal NHS Foundation Trust, RM3 - currently not in use
     {"ods_code": "RTP04", "npda_code": "PZ213", "active": 1},
     {"ods_code": "RJZ01", "npda_code": "PZ215", "active": 1},

--- a/rcpch_nhs_organisations/hospitals/management/commands/seed_functions/pdus.py
+++ b/rcpch_nhs_organisations/hospitals/management/commands/seed_functions/pdus.py
@@ -45,8 +45,8 @@ def seed_pdus():
         if Organisation.objects.filter(ods_code=pdu["ods_code"]).exists():
             # the ods_code provided is for an existing organisation, update to include PDU
             paediatric_diabetes_unit, created = (
-                PaediatricDiabetesUnit.objects.update_or_create(
-                    pz_code=pdu["npda_code"], active=pdu["active"], unit_name=pdu.get("unit_name", None)
+                PaediatricDiabetesUnit.objects.update_or_create(pz_code=pdu["npda_code"],
+                    defaults={"active": pdu["active"], "unit_name": pdu.get("unit_name", None)}
                 )
             )
             Organisation.objects.filter(ods_code=pdu["ods_code"]).update(
@@ -61,8 +61,8 @@ def seed_pdus():
 
                 # create the PDU
                 paediatric_diabetes_unit, created = (
-                    PaediatricDiabetesUnit.objects.update_or_create(
-                        pz_code=pdu["npda_code"], active=pdu["active"], unit_name=pdu.get("unit_name", None)
+                    PaediatricDiabetesUnit.objects.update_or_create(pz_code=pdu["npda_code"],
+                        defaults={"active": pdu["active"], "unit_name": pdu.get("unit_name", None)}
                     )
                 )
                 # get the trust
@@ -79,8 +79,8 @@ def seed_pdus():
                 # the ods_code provided is for a Local Health Board, update all the related organisations
                 # create the PDU
                 paediatric_diabetes_unit, created = (
-                    PaediatricDiabetesUnit.objects.update_or_create(
-                        pz_code=pdu["npda_code"], active=pdu["active"], unit_name=pdu.get("unit_name", None)
+                    PaediatricDiabetesUnit.objects.update_or_create(pz_code=pdu["npda_code"],
+                        defaults={"active": pdu["active"], "unit_name": pdu.get("unit_name", None)}
                     )
                 )
                 # get the local health board
@@ -136,8 +136,8 @@ def seed_pdus():
 
                     if parent_trust is not None:
                         paediatric_diabetes_unit, created = (
-                            PaediatricDiabetesUnit.objects.update_or_create(
-                                pz_code=pdu["npda_code"], active=pdu["active"], unit_name=pdu.get("unit_name", None)
+                            PaediatricDiabetesUnit.objects.update_or_create(pz_code=pdu["npda_code"],
+                                defaults={"active": pdu["active"], "unit_name": pdu.get("unit_name", None)}
                             )
                         )
 


### PR DESCRIPTION
Found trying to deploy #118 

PZ206 was active in the constants but inactive in the live database.

This led to a crash because the seed function was trying to insert a new PDU rather than modifying the existing one to toggle active.