### PR TITLE
Sync inactive pdu data between live and seed function

### DIFF
--- a/rcpch_nhs_organisations/hospitals/constants/paediatric_diabetes_units.py
+++ b/rcpch_nhs_organisations/hospitals/constants/paediatric_diabetes_units.py
@@ -71,7 +71,7 @@ PZ_CODES = [
     {"ods_code": "R1F01", "npda_code": "PZ075", "active": 1},
     {"ods_code": "RDEE4", "npda_code": "PZ076", "active": 1},
     {"ods_code": "RJE01", "npda_code": "PZ078", "active": 1},
-    # {"ods_code": "R0B01", "npda_code": "PZ080"}, # deprecated 28/3/25 in favour of PZ250
+    {"ods_code": "R0B01", "npda_code": "PZ080", "active": 0}, # deprecated 28/3/25 in favour of PZ250
     {"ods_code": "R0B01", "npda_code": "PZ250", "active": 1},
     {"ods_code": "RJ122", "npda_code": "PZ082", "active": 1, "unit_name": "EVELINA LONDON CHILDREN'S HOSPITAL"},
     {"ods_code": "RWP31", "npda_code": "PZ084", "active": 1},
@@ -134,7 +134,7 @@ PZ_CODES = [
     {"ods_code": "RJC02", "npda_code": "PZ138", "active": 1},
     {"ods_code": "RA723", "npda_code": "PZ139", "active": 1},
     {"ods_code": "RMP01", "npda_code": "PZ140", "active": 1},
-    # {"ods_code": "R0B0Q", "npda_code": "PZ141"}, deprecated 28/3/25 in favour of PZ250
+    {"ods_code": "R0B0Q", "npda_code": "PZ141", "active": 0}, # deprecated 28/3/25 in favour of PZ250
     {"ods_code": "R0B0Q", "npda_code": "PZ250", "active": 1},
     {"ods_code": "RRK98", "npda_code": "PZ144", "active": 1},
     {"ods_code": "RD816", "npda_code": "PZ145", "active": 1},
@@ -672,12 +672,12 @@ PZ_CODES_NETWORKS = [
         "network_name": "West Midlands",
         "network_code": "PN08",
     },
-    # {
-    #     "ods_code": "R0B01",
-    #     "npda_code": "PZ080",
-    #     "network_name": "North East & North Cumbria",
-    #     "network_code": "PN12",
-    # }, deprecated 28/3/25 in favour of PZ250
+    {
+        "ods_code": "R0B01",
+        "npda_code": "PZ080",
+        "network_name": "North East & North Cumbria",
+        "network_code": "PN12",
+    }, # deprecated 28/3/25 in favour of PZ250
     {
         "ods_code": "R0B01",
         "npda_code": "PZ250",
@@ -936,12 +936,12 @@ PZ_CODES_NETWORKS = [
         "network_name": "North West",
         "network_code": "PN11",
     },
-    # {
-    #     "ods_code": "R0B0Q",
-    #     "npda_code": "PZ141",
-    #     "network_name": "North East & North Cumbria",
-    #     "network_code": "PN12",
-    # }, # deprecated 28/3/25 in favour of PZ250
+    {
+        "ods_code": "R0B0Q",
+        "npda_code": "PZ141",
+        "network_name": "North East & North Cumbria",
+        "network_code": "PN12",
+    }, # deprecated 28/3/25 in favour of PZ250
     {
         "ods_code": "R0B0Q",
         "npda_code": "PZ250",
@@ -1182,12 +1182,12 @@ PZ_CODES_NETWORKS = [
         "network_name": "London & South East",
         "network_code": "PN05",
     },
-    # {
-    #     "ods_code": "RM3",  # Salford Royal Hospital is the parent, Pennine Acute Hospitals NHS Trust - the PZ code is currently not in use
-    #     "npda_code": "PZ206",
-    #     "network_name": "Unknown",
-    #     "network_code": None,
-    # },
+    {
+        "ods_code": "RM3",  # Salford Royal Hospital is the parent, Pennine Acute Hospitals NHS Trust - the PZ code is currently not in use
+        "npda_code": "PZ206",
+        "network_name": "North West",
+        "network_code": "PN11",
+    },
     {
         "ods_code": "RTP04",
         "npda_code": "PZ213",

--- a/rcpch_nhs_organisations/hospitals/models/paediatric_diabetes_unit.py
+++ b/rcpch_nhs_organisations/hospitals/models/paediatric_diabetes_unit.py
@@ -59,6 +59,12 @@ class PaediatricDiabetesUnit(models.Model):
             case "PZ125":
                 # PZ125 (THE MAIDSTONE HOSPITAL) merged into PZ253 MAIDSTONE AND TUNBRIDGE WELLS NHS TRUST (Jan 25)
                 return Organisation.objects.filter(ods_code="RWF03")
+            case "PZ080":
+                # PZ080 (SUNDERLAND ROYAL HOSPITAL) merged into PZ250 SOUTH TYNESIDE AND SUNDERLAND NHS FOUNDATION TRUST (Mar 25)
+                return Organisation.objects.filter(ods_code="R0B01")
+            case "PZ141":
+                # PZ141 (SOUTH TYNESIDE DISTRICT GENERAL HOSPITAL) merged into PZ250 SOUTH TYNESIDE AND SUNDERLAND NHS FOUNDATION TRUST (Mar 25)
+                return Organisation.objects.filter(ods_code="R0B0Q")
 
         return self.paediatric_diabetes_unit_organisations.all()
 

--- a/rcpch_nhs_organisations/hospitals/serializers/trust.py
+++ b/rcpch_nhs_organisations/hospitals/serializers/trust.py
@@ -121,6 +121,10 @@ class PaediatricDiabetesUnitWithNestedParentSerializer(serializers.ModelSerializ
             "PZ216": "RWF",
             # PZ125 (THE MAIDSTONE HOSPITAL) merged into PZ253 MAIDSTONE AND TUNBRIDGE WELLS NHS TRUST (Jan 25)
             "PZ125": "RWF",
+            # PZ080 (SUNDERLAND ROYAL HOSPITAL) merged into PZ250 SOUTH TYNESIDE AND SUNDERLAND NHS FOUNDATION TRUST (Mar 25)
+            "PZ080": "R0B",
+            # PZ141 (SOUTH TYNESIDE DISTRICT GENERAL HOSPITAL) merged into PZ250 SOUTH TYNESIDE AND SUNDERLAND NHS FOUNDATION TRUST (Mar 25)
+            "PZ141": "R0B",
         }
 
         if obj.pz_code in inactive_pdu_to_trust_mapping:


### PR DESCRIPTION
Tidy up following #117, #118 and #119. Also return organisations and networks for all units even if inactive