### PR TITLE
Django bumps

### DIFF
--- a/requirements/common-requirements.txt
+++ b/requirements/common-requirements.txt
@@ -3,15 +3,11 @@ requests==2.32.5
 python-dateutil==2.9.0.post0
 
 # third party imports
-# https://github.com/openwisp/django-rest-framework-gis?tab=readme-ov-file#compatibility-with-drf-django-and-python
-# djangorestframework-gis only supports Django < 5.1.x
-django==5.2.8
-# djangorestframework-gis only supports drf < 3.15.x
-djangorestframework==3.15.2
-djangorestframework-gis==1.1.0
-drf-spectacular==0.28.0
-# djangorestframework-gis only supports django-filter > 25.0.x
-django-filter==24.3
+django==5.2.10
+djangorestframework==3.16.1
+djangorestframework-gis==1.2.0
+drf-spectacular==0.29.0
+django-filter==25.2
 markdown==3.8 # support for browsable API
 psycopg2-binary==2.9.10
 whitenoise==6.9.0


### PR DESCRIPTION
Fixes security warnings:

- https://github.com/rcpch/rcpch-nhs-organisations/security/dependabot/37
- https://github.com/rcpch/rcpch-nhs-organisations/security/dependabot/36

It also looks like we don't need to pin the various drf-gis dependencies