### PR TITLE
Pin GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# Dependabot configuration.
+#
+# - Keeps GitHub Actions up to date.
+# - Actions are pinned to commit SHAs in workflows; Dependabot still
+#   recognises and updates SHA-pinned uses, preserving the trailing
+#   "# vX.Y.Z" version comment when it opens an update PR.
+# - The cooldown.default-days value gives 7 days between an upstream
+#   release and Dependabot raising a PR for it. This reduces exposure to
+#   compromised releases that get yanked or revoked shortly after publication
+#   (a common supply-chain attack pattern), while still keeping us current.
+#
+# Docs: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/.github/workflows/main_rcpch-nhs-organisations.yml
+++ b/.github/workflows/main_rcpch-nhs-organisations.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           lfs: true # ensures large files are downloaded using Git LFS
 
       - name: Set up Python version
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@0f07f7f756721ebd886c2462646a35f78a8bc4de # v1
         with:
           python-version: "3.11"
 
@@ -34,7 +34,7 @@ jobs:
         run: s/get-build-info > build_info.json
 
       - name: "Deploy to Azure Web App"
-        uses: azure/webapps-deploy@v2 # Update the version to v2
+        uses: azure/webapps-deploy@5cfb776471c748b351e1ebf5770e208a54ace016 # v2
         with:
           app-name: "RCPCH-NHS-organisations"
           publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_A76B7421A08D44778EBB49AB30B51B3D }}
@@ -46,10 +46,10 @@ jobs:
     needs: build-and-deploy
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python version
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@0f07f7f756721ebd886c2462646a35f78a8bc4de # v1
         with:
           python-version: "3.11"
 
@@ -64,7 +64,7 @@ jobs:
         run: mkdocs build --config-file documentation/mkdocs.yml --verbose || exit 1
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: documentation/site
@@ -74,10 +74,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python version
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@0f07f7f756721ebd886c2462646a35f78a8bc4de # v1
         with:
           python-version: "3.11"
 
@@ -95,7 +95,7 @@ jobs:
         run: ls -la documentation/site || echo "MkDocs build failed or output directory is missing!"
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: documentation/site

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           lfs: true # ensures large files are downloaded using Git LFS
 


### PR DESCRIPTION
Pin third-party GitHub Actions to immutable commit SHAs (with a trailing version-tag comment for human readability) to mitigate supply-chain attacks via tag re-pointing. Add a Dependabot config that maintains the github-actions ecosystem with a 7-day cooldown so we don't adopt brand-new releases until any yanks/revocations have surfaced.

Each workflow has a header comment explaining the SHA-pinning convention and linking to the GitHub security-hardening docs and the mheap/pin-github-action tool.

Following process from @pacharanero in https://github.com/rcpch/rcpchgrowth-python/pull/87.